### PR TITLE
Fix borken JSON and cli argument in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,14 +24,18 @@ convert it for use in a QR.
 ### Test Steps
 
 1. Generate the CSCA and DSC with ```./gen-csca-dsc.sh```	
-1. Run the command: ```echo "{'A': 1234}" | python3.8 hc1_sign.py | python3.8 hc1_verify.py```
+1. Run the command: ```echo '{"A": 1234}' | python3.8 hc1_sign.py | python3.8 hc1_verify.py```
 1. You should see the output: ```{"A": 1234}```
 
-```echo '{ "Foo":1, "Bar":{ "Field1": "a value",   "integer":1212112121 }}' | python3.8 hc1_sign.py | python3.8 hc1_verify.py prettyprint-json```
+```bash
+echo '{"Foo":1, "Bar":{"Field1":"a value", "integer":1212112121}}' | \
+    python3 hc1_sign.py | \
+    python3 hc1_verify.py --prettyprint-json
+```
 
 Which should output:
 
-```
+```json
 {
     "Foo": 1, 
     "Bar": {
@@ -48,4 +52,7 @@ Testing against the AT cases:
 1. Fetch the Base64 from https://dev.a-sit.at/certservice
 1. Remove the first 2 bytes and do
 
-   ```pbpaste| sed -e 's/^00//' | python3.8 hc1_verify.py --base64 --ignore-signature --cbor```
+   ```bash
+   pbpaste | sed -e 's/^00//' | \
+       python3 hc1_verify.py --base64 --ignore-signature --cbor
+   ```


### PR DESCRIPTION
JSON strings only support double quotes `"` and `--` was missing in `--prettyprint-json`. Also I changed `python3.8` to `python3`, since people might not have that exact version and `python3` is enough. Further I added syntax highlighting to the code examples and manually line wrapped them for better readability.