### PR TITLE
Fix broken tests after script renaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ convert it for use in a QR.
 ### Test Steps
 
 1. Generate the CSCA and DSC with ```./gen-csca-dsc.sh```	
-1. Run the command: ```echo "{'A': 1234}" | python3.8 hc1_sign.py | python3.8 hc1_verify.py```
+1. Run the command: ```echo '{"A": 1234}' | python3.8 hc1_sign.py | python3.8 hc1_verify.py```
 1. You should see the output: ```{"A": 1234}```
 
 ```echo '{ "Foo":1, "Bar":{ "Field1": "a value",   "integer":1212112121 }}' | python3.8 hc1_sign.py | python3.8 hc1_verify.py prettyprint-json```

--- a/test.sh
+++ b/test.sh
@@ -7,5 +7,4 @@ test -f masterlist-dsc.pem || sh  gen-csca-dsc.sh
 
 # JSON / CBOR / COSE / ZLIB / Base45
 #
-echo '{ "A" : "B" }' | ${PYTHON} cose_sign.py |  ${PYTHON} cose_verify.py
-
+echo '{ "A" : "B" }' | ${PYTHON} hc1_sign.py |  ${PYTHON} hc1_verify.py


### PR DESCRIPTION
`./test.sh` failed with:
```$ ./test.sh
python3: can't open file 'cose_verify.py': [Errno 2] No such file or directory
python3: can't open file 'cose_sign.py': [Errno 2] No such file or directory
```
Because `cose_` prefix was changed to `hc1_` in 40c60a8.