### PR TITLE
fix filename typos in examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,11 +23,11 @@ convert it for use in a QR.
 
 ### Decoding a barcode from production (i.e. a DCC in the wild)
 
-     qrdecode photo.jpg | python3 ./hc1_verify -v -U -p
+     qrdecode photo.jpg | python3 ./hc1_verify.py -v -U -p
 
 or
 
-     qrdecode photo.jpg | python3 ./hc1_verify -v -i -p
+     qrdecode photo.jpg | python3 ./hc1_verify.py -v -i -p
 
 The first will check against the Dutch copy of the eHealth trustlist; the second version, with the -i, will not check the actual signature. The typical output will look like:
 

--- a/test.sh
+++ b/test.sh
@@ -7,5 +7,4 @@ test -f masterlist-dsc.pem || sh  gen-csca-dsc.sh
 
 # JSON / CBOR / COSE / ZLIB / Base45
 #
-echo '{ "A" : "B" }' | ${PYTHON} cose_sign.py |  ${PYTHON} cose_verify.py
-
+echo '{ "A" : "B" }' | ${PYTHON} hc1_sign.py |  ${PYTHON} hc1_verify.py


### PR DESCRIPTION
Hello,

I fixed several filename typos in README and the example script.